### PR TITLE
fix wrong reference in w06_t04

### DIFF
--- a/w06_hpo_bo/t04_surrogate_models.tex
+++ b/w06_hpo_bo/t04_surrogate_models.tex
@@ -217,7 +217,7 @@
     \centering
     \includegraphics[width=0.7\textwidth]{images/surrogate_models/kernel_hp_mcmc.jpg}
     
-    \footnotesize{Image source: \lit{\href{https://arxiv.org/pdf/1502.05700.pdf}{Snoek et al. 2015}}}
+    \footnotesize{Image source: \lit{\href{https://arxiv.org/pdf/1206.2944.pdf}{Snoek et al. 2012}}}
 }
 
 


### PR DESCRIPTION
before:
![Screenshot from 2021-03-29 16-26-12](https://user-images.githubusercontent.com/33290713/112852382-271e3d80-90ac-11eb-9c6a-1948aee5a999.png)
that cited the wrong paper ( [https://arxiv.org/pdf/1502.05700.pdf](https://arxiv.org/pdf/1502.05700.pdf) )
now:
![Screenshot from 2021-03-29 16-25-57](https://user-images.githubusercontent.com/33290713/112852451-3e5d2b00-90ac-11eb-84ca-ee633351a894.png)
here is thre correct one ( [https://arxiv.org/pdf/1206.2944.pdf](https://arxiv.org/pdf/1206.2944.pdf) )